### PR TITLE
Switch template network from rinkeby to mainnet

### DIFF
--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -34,7 +34,7 @@ dataSources:
 templates:
   - kind: ethereum/contract
     name: Pair
-    network: rinkeby
+    network: mainnet
     source:
       abi: Pair
     mapping:


### PR DESCRIPTION
This PR changes the template network from `rinkeby` to `mainnet` to be consistent with the `Factory` data source.

Fixing this makes the subgraph deployable out of the box.