### PR TITLE
Update dependency version due to "permission denied" error in v0.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "watch-local": "graph deploy graphprotocol/Uniswap2 --watch --debug --node http://127.0.0.1:8020/ --ipfs http://localhost:5001"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "^0.20.0",
+    "@graphprotocol/graph-cli": "^0.21.3",
     "@graphprotocol/graph-ts": "^0.20.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.21.3",
-    "@graphprotocol/graph-ts": "^0.20.0",
+    "@graphprotocol/graph-ts": "^0.20.1",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "eslint": "^6.2.2",


### PR DESCRIPTION
While working with v2-subgraph, I encountered a "permission denied" error when using the v0.20.0 version of `@graphprotocol/graph-cli`. It appears that there might be an issue or the specific version might have been removed from GitHub, causing this error. However, I found that upgrading to v0.20.3 solves the issue and the library works as expected.

![image](https://github.com/Uniswap/v2-subgraph/assets/120671243/5ea885c8-30f1-40df-bb75-e06fb0722569)


This PR proposes updating the version of `@graphprotocol/graph-cli` to v0.20.3 to avoid this problem for others who might use or contribute to this repository in the future.

Changes:
- Updated `@graphprotocol/graph-cli` from v0.20.0 to v0.20.3 and `@graphprotocol/graph-ts` from v0.20.0 to v0.20.1 in `package.json`.
