### PR TITLE
Added fix to avoid parsing the broken token decimals

### DIFF
--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -113,14 +113,14 @@ export function fetchTokenName(tokenAddress: Address): string {
   return nameValue
 }
 
-// HOT FIX: we cant implement try catch for overflow catching so skip total supply parsing on these tokens that overflow 
+// HOT FIX: we cant implement try catch for overflow catching so skip total supply and decimals parsing on these tokens that overflow 
 // TODO: find better way to handle overflow 
-let SKIP_TOTAL_SUPPLY: string[] = [
+let SKIP_TOTAL_SUPPLY_AND_DECIMALS: string[] = [
   "0x0000000000bf2686748e1c0255036e7617e7e8a5"
 ]
 
 export function fetchTokenTotalSupply(tokenAddress: Address): BigInt {
-  if (SKIP_TOTAL_SUPPLY.includes(tokenAddress.toHexString())) {
+  if (SKIP_TOTAL_SUPPLY_AND_DECIMALS.includes(tokenAddress.toHexString())) {
     return BigInt.fromI32(0)
   }
 
@@ -134,6 +134,9 @@ export function fetchTokenTotalSupply(tokenAddress: Address): BigInt {
 }
 
 export function fetchTokenDecimals(tokenAddress: Address): BigInt {
+  if (SKIP_TOTAL_SUPPLY_AND_DECIMALS.includes(tokenAddress.toHexString())) {
+    return BigInt.fromI32(0)
+  }
   // static definitions overrides
   let staticDefinition = TokenDefinition.fromAddress(tokenAddress)
   if (staticDefinition != null) {


### PR DESCRIPTION
Not sure how to test this, but the same token also returns a huge value for decimals and could cause further issues